### PR TITLE
Fix ArticleVoter

### DIFF
--- a/Security/Authorization/Voter/ArticleVoter.php
+++ b/Security/Authorization/Voter/ArticleVoter.php
@@ -32,24 +32,7 @@ class ArticleVoter implements VoterInterface
 
     public function supportsClass($class)
     {
-        try
-        {
-            $testObject = new $class();
-
-            if ($testObject instanceof ArticleInterface)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        catch(\Exception $e)
-        {
-            return false;
-        }
-
+        return in_array(ArticleInterface::class, class_implements($class));
     }
 
     public function vote(TokenInterface $token, $object, array $attributes)
@@ -129,5 +112,4 @@ class ArticleVoter implements VoterInterface
 
         }
     }
-
 }


### PR DESCRIPTION
```
Type error: Too few arguments to function ED\BlogBundle\Security\Authorization\Voter\ArticleVoter::__construct(), 0 passed in /var/www/html/vendor/ridji/blog-bundle/Security/Authorization/Voter/ArticleVoter.php on line 37 and exactly 1 expected
```